### PR TITLE
feat: run cmd

### DIFF
--- a/.github/Readme.md
+++ b/.github/Readme.md
@@ -19,10 +19,11 @@ cp build/dlt ~/go/bin/dlt
 Depending on what you want to achieve with `dlt` there are two commands available. A quick summary of what they do
 and when to use them can be found below:
 
-|                                 | Description                                                                                                                                                                                                                                                                                 | Recommendation                                                                                                                                    |
-|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| **sync**                        | Starts an incremental sync based on a start bundle ID - first bundle of the pool by default. The sync runs until all bundles are loaded into the destination. When executing `dlt sync` again, it checks the latest loaded bundle ID in order to incrementally extend the existing dataset. | Generally recommended to sync a whole pool dataset into a destination. Can be used with a cronjob to keep the dataset in the destination updated. |
-| **partial-sync**                | Starts a partial sync from a start to an end bundle ID. Doesn't check the destination for already loaded bundles or duplicates.                                                                                                                                                             | Recommended to sync a specified range of bundles or to back-fill an existing dataset.                                                             |
+|                  | Description                                                                                                                                                                                                                                                                                 | Recommendation                                                                                                                                |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| **sync**         | Starts an incremental sync based on a start bundle ID - first bundle of the pool by default. The sync runs until all bundles are loaded into the destination. When executing `dlt sync` again, it checks the latest loaded bundle ID in order to incrementally extend the existing dataset. | Generally recommended to sync a whole pool dataset into a destination. Can be used with `run` to keep the dataset in the destination updated. |
+| **run**          | Runs a supervised incremental sync in a given hour interval (default: 2).                                                                                                                                                                                                                   | Recommended to keep a dataset updated with incrementally added data.                                                                          |
+| **partial-sync** | Starts a partial sync from a start to an end bundle ID. Doesn't check the destination for already loaded bundles or duplicates.                                                                                                                                                             | Recommended to sync a specified range of bundles or to back-fill an existing dataset.                                                         |
 
 ### Config
 The **dlt** config is used to define the source and the destination. With the first executed
@@ -37,7 +38,14 @@ For each sync process, a connection consisting of a source and a destination is 
 ```bash
 dlt sync --connection connection_1
 ```
-To start the incremental sync from a certain height, simple use the `--from-bundle-id` flag. This won't affect the incremental sync, but only the initial start bundle ID of the dataset.
+To start the incremental sync from a certain height, simply use the `--from-bundle-id` flag. This won't affect the incremental sync, but only the initial start bundle ID of the dataset.
+
+### `run` 
+**Usage:**
+```bash
+dlt run --connection connection_1 --interval 1
+```
+To start the supervised incremental sync that is executed in an 1-hour interval, simply use the `--interval` flag that expects the hour value.
 
 ### `partial-sync`
 **Usage:**

--- a/cmd/dlt/commands/partial-sync.go
+++ b/cmd/dlt/commands/partial-sync.go
@@ -2,10 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"github.com/KYVENetwork/KYVE-DLT/destinations"
-	"github.com/KYVENetwork/KYVE-DLT/loader"
-	"github.com/KYVENetwork/KYVE-DLT/loader/collector"
-	"github.com/KYVENetwork/KYVE-DLT/schema"
 	"github.com/KYVENetwork/KYVE-DLT/utils"
 	"github.com/spf13/cobra"
 	"time"
@@ -40,74 +36,19 @@ var partialSyncCmd = &cobra.Command{
 	Use:   "partial-sync",
 	Short: "Load a specific range of bundles",
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := utils.LoadConfig(configPath)
+		logger.Info().Int64("from_bundle_id", fromBundleId).Int64("to_bundle_id", toBundleId).Msg("setting up partial sync")
+		loader, err := setupLoader(configPath, true, fromBundleId, toBundleId)
 		if err != nil {
+			logger.Error().Str("err", err.Error()).Msg("failed to set up loader")
 			return
 		}
 
-		source, destination, err := utils.GetConnectionDetails(config, connection)
-		if err != nil {
-			logger.Error().Str("err", err.Error()).Msg("failed to read connection")
-			return
-		}
-
-		logger.Info().Int64("from_bundle_id", fromBundleId).Int64("to_bundle_id", toBundleId).Msg("Starting partial sync ...")
 		startTime := time.Now().Unix()
 
-		var dest destinations.Destination
-		switch destination.Type {
-		case "big_query":
-			bigQueryDest := destinations.NewBigQuery(destinations.BigQueryConfig{
-				ProjectId:           destination.ProjectID,
-				DatasetId:           destination.DatasetID,
-				TableId:             destination.TableID,
-				BigQueryWorkerCount: destination.WorkerCount,
-				BucketWorkerCount:   destination.BucketWorkerCount,
-			})
-			dest = &bigQueryDest
-		case "postgres":
-			postgresDest := destinations.NewPostgres(destinations.PostgresConfig{
-				ConnectionUrl:       destination.ConnectionURL,
-				TableName:           destination.TableName,
-				PostgresWorkerCount: destination.WorkerCount,
-			})
-			dest = &postgresDest
-		default:
-			panic(fmt.Errorf("destination type not supported: %v", destination.Type))
-		}
+		logger.Info().Int64("from_bundle_id", fromBundleId).Int64("to_bundle_id", toBundleId).Msg("starting partial sync")
 
-		sourceConfig := collector.SourceConfig{
-			PoolId:       int64(source.PoolID),
-			FromBundleId: fromBundleId,
-			ToBundleId:   toBundleId,
-			StepSize:     int64(source.StepSize),
-			Endpoint:     source.Endpoint,
-			PartialSync:  true,
-		}
+		loader.Start(y)
 
-		var sourceSchema schema.DataSource
-		switch source.Schema {
-		case "base":
-			sourceSchema = schema.Base{}
-		case "tendermint":
-			sourceSchema = schema.Tendermint{}
-		case "tendermint_preprocessed":
-			sourceSchema = schema.TendermintPreProcessed{}
-		default:
-			panic(fmt.Errorf("source schema not supported: %v", source.Schema))
-		}
-
-		loaderConfig := loader.Config{
-			ChannelSize:    config.Loader.ChannelSize,
-			CsvWorkerCount: config.Loader.CSVWorkerCount,
-			SourceSchema:   sourceSchema,
-		}
-
-		loader.NewLoader(loaderConfig, sourceConfig, dest).Start(y)
-
-		logger.Info().Msg(fmt.Sprintf("Time: %d seconds", time.Now().Unix()-startTime))
-	},
-	PreRun: func(cmd *cobra.Command, args []string) {
-
+		logger.Info().Msg(fmt.Sprintf("Finished sync! Took %d seconds", time.Now().Unix()-startTime))
 	},
 }

--- a/cmd/dlt/commands/root.go
+++ b/cmd/dlt/commands/root.go
@@ -10,7 +10,7 @@ var (
 	configPath   string
 	connection   string
 	fromBundleId int64
-	interval     int64
+	interval     float64
 	logger       = utils.DltLogger("cmd")
 	toBundleId   int64
 	y            bool

--- a/cmd/dlt/commands/root.go
+++ b/cmd/dlt/commands/root.go
@@ -10,6 +10,7 @@ var (
 	configPath   string
 	connection   string
 	fromBundleId int64
+	interval     int64
 	logger       = utils.DltLogger("cmd")
 	toBundleId   int64
 	y            bool

--- a/cmd/dlt/commands/run.go
+++ b/cmd/dlt/commands/run.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/KYVENetwork/KYVE-DLT/utils"
+	"github.com/spf13/cobra"
+	"math"
+	"time"
+)
+
+func init() {
+	runCmd.Flags().StringVar(&configPath, "config", utils.DefaultHomePath, "set custom config path")
+
+	runCmd.Flags().StringVar(&connection, "connection", "", "name of the connection to sync")
+	if err := runCmd.MarkFlagRequired("connection"); err != nil {
+		panic(fmt.Errorf("flag 'connection' should be required: %w", err))
+	}
+
+	runCmd.Flags().Int64Var(&interval, "interval", 2, "interval of the sync process (in hours)")
+
+	runCmd.Flags().Int64Var(&fromBundleId, "from-bundle-id", 0, "start bundle-id of the initial sync process")
+
+	runCmd.Flags().BoolVarP(&y, "yes", "y", false, "automatically answer yes for all questions")
+
+	rootCmd.AddCommand(runCmd)
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a supervised incremental sync",
+	Run: func(cmd *cobra.Command, args []string) {
+		logger.Info().Int64("from_bundle_id", fromBundleId).Msg("setting up supervised incremental sync")
+		loader, err := setupLoader(configPath, false, fromBundleId, math.MaxInt64)
+		if err != nil {
+			logger.Error().Str("err", err.Error()).Msg("failed to set up loader")
+			return
+		}
+
+		startTime := time.Now().Unix()
+
+		logger.Info().Int64("from_bundle_id", fromBundleId).Str("interval", fmt.Sprintf("%v hours", interval)).Msg("starting supervised incremental sync")
+
+		for {
+			loader.Start(y)
+			logger.Info().Msg(fmt.Sprintf("Finished sync! Took %d seconds", time.Now().Unix()-startTime))
+
+			logger.Info().Msg(fmt.Sprintf("Waiting %d hours before starting next sync", interval))
+			time.Sleep(time.Duration(interval) * time.Hour)
+		}
+	},
+}

--- a/cmd/dlt/commands/run.go
+++ b/cmd/dlt/commands/run.go
@@ -16,11 +16,9 @@ func init() {
 		panic(fmt.Errorf("flag 'connection' should be required: %w", err))
 	}
 
-	runCmd.Flags().Int64Var(&interval, "interval", 2, "interval of the sync process (in hours)")
+	runCmd.Flags().Float64Var(&interval, "interval", 2, "interval of the sync process (in hours)")
 
 	runCmd.Flags().Int64Var(&fromBundleId, "from-bundle-id", 0, "start bundle-id of the initial sync process")
-
-	runCmd.Flags().BoolVarP(&y, "yes", "y", false, "automatically answer yes for all questions")
 
 	rootCmd.AddCommand(runCmd)
 }
@@ -38,14 +36,16 @@ var runCmd = &cobra.Command{
 
 		startTime := time.Now().Unix()
 
+		sleepDuration := time.Duration(interval * float64(time.Hour))
+
 		logger.Info().Int64("from_bundle_id", fromBundleId).Str("interval", fmt.Sprintf("%v hours", interval)).Msg("starting supervised incremental sync")
 
 		for {
-			loader.Start(y)
+			loader.Start(true)
 			logger.Info().Msg(fmt.Sprintf("Finished sync! Took %d seconds", time.Now().Unix()-startTime))
 
-			logger.Info().Msg(fmt.Sprintf("Waiting %d hours before starting next sync", interval))
-			time.Sleep(time.Duration(interval) * time.Hour)
+			logger.Info().Msg(fmt.Sprintf("Waiting %f hours before starting next sync", interval))
+			time.Sleep(sleepDuration)
 		}
 	},
 }

--- a/cmd/dlt/commands/setup.go
+++ b/cmd/dlt/commands/setup.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/KYVENetwork/KYVE-DLT/destinations"
+	"github.com/KYVENetwork/KYVE-DLT/loader"
+	"github.com/KYVENetwork/KYVE-DLT/loader/collector"
+	"github.com/KYVENetwork/KYVE-DLT/schema"
+	"github.com/KYVENetwork/KYVE-DLT/utils"
+)
+
+func setupLoader(configPath string, partialSync bool, from, to int64) (*loader.Loader, error) {
+	config, err := utils.LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %v", err)
+	}
+
+	source, destination, err := utils.GetConnectionDetails(config, connection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read connection: %v", err)
+	}
+
+	var dest destinations.Destination
+	switch destination.Type {
+	case "big_query":
+		bigQueryDest := destinations.NewBigQuery(destinations.BigQueryConfig{
+			ProjectId:           destination.ProjectID,
+			DatasetId:           destination.DatasetID,
+			TableId:             destination.TableID,
+			BigQueryWorkerCount: destination.WorkerCount,
+			BucketWorkerCount:   destination.BucketWorkerCount,
+		})
+		dest = &bigQueryDest
+	case "postgres":
+		postgresDest := destinations.NewPostgres(destinations.PostgresConfig{
+			ConnectionUrl:       destination.ConnectionURL,
+			TableName:           destination.TableName,
+			PostgresWorkerCount: destination.WorkerCount,
+		})
+		dest = &postgresDest
+	default:
+		panic(fmt.Errorf("destination type not supported: %v", destination.Type))
+	}
+
+	sourceConfig := collector.SourceConfig{
+		PoolId:       int64(source.PoolID),
+		FromBundleId: from,
+		ToBundleId:   to,
+		StepSize:     int64(source.StepSize),
+		Endpoint:     source.Endpoint,
+		PartialSync:  partialSync,
+	}
+
+	var sourceSchema schema.DataSource
+	switch source.Schema {
+	case "base":
+		sourceSchema = schema.Base{}
+	case "tendermint":
+		sourceSchema = schema.Tendermint{}
+	case "tendermint_preprocessed":
+		sourceSchema = schema.TendermintPreProcessed{}
+	default:
+		panic(fmt.Errorf("source schema not supported: %v", source.Schema))
+	}
+
+	loaderConfig := loader.Config{
+		ChannelSize:    config.Loader.ChannelSize,
+		CsvWorkerCount: config.Loader.CSVWorkerCount,
+		SourceSchema:   sourceSchema,
+	}
+
+	return loader.NewLoader(loaderConfig, sourceConfig, dest), nil
+}

--- a/loader/collector/bundles_collector.go
+++ b/loader/collector/bundles_collector.go
@@ -62,6 +62,11 @@ func (s Source) FetchBundles(offset int64, handler func(bundles []Bundle, err er
 		handler(nil, fmt.Errorf("initial bundle request failed: %s", responseError.Error()))
 	}
 
+	if len(initialBundles) == 0 {
+		handler(nil, fmt.Errorf("could not find any bundles yet; from-bundle-id too high or interval too short"))
+		return
+	}
+
 	highestBundleId, err := strconv.ParseInt(initialBundles[len(initialBundles)-1].Id, 10, 64)
 	if err != nil {
 		handler(nil, fmt.Errorf("malformed bundle response, invalid bundle-id: %s", err.Error()))
@@ -116,7 +121,7 @@ func (s Source) FetchBundles(offset int64, handler func(bundles []Bundle, err er
 		handler(bundles, nil)
 
 		if nextKey == "" {
-			handler(nil, errors.New("invalid nextKey returned or end was reached early"))
+			logger.Info().Msg("reached last bundle")
 			return
 		}
 		paginationKey = nextKey

--- a/loader/collector/bundles_collector.go
+++ b/loader/collector/bundles_collector.go
@@ -68,8 +68,8 @@ func (s Source) FetchBundles(offset int64, handler func(bundles []Bundle, err er
 		return
 	}
 
-	if highestBundleId > s.toBundleId {
-		logger.Info().Msg("reached to_bundle_id")
+	if highestBundleId > s.toBundleId || paginationKey == "" {
+		logger.Info().Msg("reached last bundle")
 
 		var bundles []Bundle
 		for _, b := range initialBundles {

--- a/loader/service.go
+++ b/loader/service.go
@@ -15,6 +15,9 @@ var (
 )
 
 func (loader *Loader) Start(y bool) {
+	loader.mu.Lock()
+	defer loader.mu.Unlock()
+
 	logger.Debug().Msg(fmt.Sprintf("BundleConfig: %#v", loader.sourceConfig))
 	logger.Debug().Msg(fmt.Sprintf("ConcurrencyConfig: %#v", loader.config))
 
@@ -162,7 +165,7 @@ func (loader *Loader) dataRowWorker(name string) {
 		loader.dataRowChannel <- items
 
 		logger.Info().
-			Str("fromKey", item.status.FromKey).
+			Int64("fromBundleId", item.status.FromBundleId).
 			Str("toKey", item.status.ToKey).
 			Int64("toBundleId", item.status.ToBundleId).
 			Int("bundles", len(item.bundles)).

--- a/loader/types.go
+++ b/loader/types.go
@@ -25,6 +25,8 @@ type Loader struct {
 	destination  destinations.Destination
 
 	latestBundleId *int64
+
+	mu sync.Mutex
 }
 
 type Config struct {


### PR DESCRIPTION
This PR introduces the `run` command, that starts an incremental sync and executes it in an interval.

Besides this, it includes a fix that prevents a sync process loop caused by an initial sync that reaches the last bundle.