### PR TITLE
chore: update extracted_at

### DIFF
--- a/loader/service.go
+++ b/loader/service.go
@@ -129,6 +129,7 @@ func (loader *Loader) bundlesCollector() {
 						FromKey:      bundles[0].FromKey,
 						ToKey:        bundles[len(bundles)-1].ToKey,
 						DataSize:     0,
+						ExtractedAt:  time.Now().Format(time.RFC3339),
 					},
 				}
 			}
@@ -151,7 +152,7 @@ func (loader *Loader) dataRowWorker(name string) {
 		items := make([]schema.DataRow, 0)
 		for _, k := range item.bundles {
 			utils.TryWithExponentialBackoff(func() error {
-				newRows, err := loader.config.SourceSchema.DownloadAndConvertBundle(k)
+				newRows, err := loader.config.SourceSchema.DownloadAndConvertBundle(k, item.status.ExtractedAt)
 				if err != nil {
 					return err
 				}

--- a/loader/status.go
+++ b/loader/status.go
@@ -1,6 +1,8 @@
 package loader
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Status struct {
 	FromBundleId int64
@@ -8,6 +10,7 @@ type Status struct {
 	FromKey      string
 	ToKey        string
 	DataSize     int64
+	ExtractedAt  string
 }
 
 func (s Status) String() string {

--- a/schema/base.go
+++ b/schema/base.go
@@ -8,7 +8,6 @@ import (
 	"github.com/KYVENetwork/KYVE-DLT/utils"
 	"github.com/google/uuid"
 	"strconv"
-	"time"
 )
 
 type BaseItem struct {
@@ -80,7 +79,7 @@ CREATE TABLE IF NOT EXISTS %s (
     `, name)
 }
 
-func (t Base) DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow, error) {
+func (t Base) DownloadAndConvertBundle(bundle collector.Bundle, extractedAt string) ([]DataRow, error) {
 	bundleBuffer, err := downloadBundle(bundle)
 	if err != nil {
 		return nil, err
@@ -104,7 +103,7 @@ func (t Base) DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow, erro
 		}
 		columns = append(columns, BaseRow{
 			_dlt_raw_id:       "",
-			_dlt_extracted_at: time.Now().Format(time.RFC3339),
+			_dlt_extracted_at: extractedAt,
 			value:             string(jsonValue),
 			key:               kyveItem.Key,
 			bundle_id:         int64(bundleId),

--- a/schema/tendermint.go
+++ b/schema/tendermint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/KYVENetwork/KYVE-DLT/utils"
 	"github.com/google/uuid"
 	"strconv"
-	"time"
 )
 
 type TendermintItem struct {
@@ -80,7 +79,7 @@ CREATE TABLE IF NOT EXISTS %s (
     `, name)
 }
 
-func (t Tendermint) DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow, error) {
+func (t Tendermint) DownloadAndConvertBundle(bundle collector.Bundle, extractedAt string) ([]DataRow, error) {
 	bundleBuffer, err := downloadBundle(bundle)
 	if err != nil {
 		return nil, err
@@ -109,7 +108,7 @@ func (t Tendermint) DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow
 		}
 		columns = append(columns, TendermintRow{
 			_dlt_raw_id:       "",
-			_dlt_extracted_at: time.Now().Format(time.RFC3339),
+			_dlt_extracted_at: extractedAt,
 			value:             string(jsonValue),
 			height:            int64(height),
 			bundle_id:         int64(bundleId),

--- a/schema/tendermint_preprocessed.go
+++ b/schema/tendermint_preprocessed.go
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS %s (
     `, name)
 }
 
-func (t TendermintPreProcessed) DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow, error) {
+func (t TendermintPreProcessed) DownloadAndConvertBundle(bundle collector.Bundle, extractedAt string) ([]DataRow, error) {
 	bundleBuffer, err := downloadBundle(bundle)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (t TendermintPreProcessed) DownloadAndConvertBundle(bundle collector.Bundle
 		for index, beginBlockItem := range kyveItem.Value.BlockResults.BeginBlockEvents {
 			columns = append(columns, TendermintPreProcessedRow{
 				_dlt_raw_id:       "",
-				_dlt_extracted_at: time.Now().Format(time.RFC3339),
+				_dlt_extracted_at: extractedAt,
 				item_type:         "begin_block_event",
 				value:             string(beginBlockItem),
 				height:            kyveItem.Key,

--- a/schema/types.go
+++ b/schema/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 type DataSource interface {
-	DownloadAndConvertBundle(bundle collector.Bundle) ([]DataRow, error)
+	DownloadAndConvertBundle(bundle collector.Bundle, extractedAt string) ([]DataRow, error)
 	GetCSVSchema() []string
 	GetBigQuerySchema() bigquery.Schema
 	GetBigQueryTimePartitioning() *bigquery.TimePartitioning


### PR DESCRIPTION
This PR updates the `_dlt_extracted_at` value. It is now set in the bundles collector to match the following scheme:

_For two data items i, j applies:_ 
`_dlt_extracted_at[i] <= _dlt_extracted_at[j] <=> block_time[i] <= block_time[j]`