### PR TITLE
chore: added new storage provider ArDrive Turbo

### DIFF
--- a/schema/storage_provider.go
+++ b/schema/storage_provider.go
@@ -21,6 +21,8 @@ func downloadBundle(bundle collector.Bundle, extra ExtraData) (DownloadResult, e
 		baseUrl = "https://arweave.net"
 	case "3":
 		baseUrl = "https://storage.kyve.network"
+	case "4":
+		baseUrl = "https://arweave.net"
 	}
 
 	// Download bundle


### PR DESCRIPTION
This PR adds the newest storage provider [Ardrive Turbo](https://ardrive.io/turbo-bundler/) with the storage provider id `4` to the KYVE DLT.